### PR TITLE
feat: rule suppression via comments

### DIFF
--- a/internal/linter/analyze.go
+++ b/internal/linter/analyze.go
@@ -68,6 +68,8 @@ func (l *Linter) Analyze(params AnalysisParams) ([]rules.Issue, error) {
 
 		issues := make([]rules.Issue, 0, FINAL_FILE_ISSUE_CAP)
 
+		suppressions := params.suppressions[filePath]
+
 		runner := rules.Runner{
 			File:           f,
 			Fset:           params.fset,
@@ -80,7 +82,8 @@ func (l *Linter) Analyze(params AnalysisParams) ([]rules.Issue, error) {
 			ShouldStop: func() bool {
 				return params.shouldStop != nil && params.shouldStop(len(allIssues)+len(issues))
 			},
-			TypesInfo: info,
+			TypesInfo:    info,
+			Suppressions: suppressions,
 		}
 
 		ast.Inspect(f, func(n ast.Node) bool {
@@ -97,6 +100,11 @@ func (l *Linter) Analyze(params AnalysisParams) ([]rules.Issue, error) {
 
 			return true
 		})
+
+		unusedWarnings := rules.CheckUnusedSuppressions(issues, suppressions)
+
+		issues = rules.FilterSuppressedIssues(issues, suppressions)
+		issues = append(issues, unusedWarnings...)
 
 		allIssues = append(allIssues, issues...)
 

--- a/internal/linter/pipeline.go
+++ b/internal/linter/pipeline.go
@@ -37,7 +37,7 @@ func (l *Linter) ProcessPath(root string) ([]rules.Issue, error) {
 			return nil, exception.InternalError("%v", err)
 		}
 
-		f, err := parser.ParseFile(fset, root, src, 0)
+		f, err := parser.ParseFile(fset, root, src, parser.ParseComments)
 
 		if err != nil {
 			return nil, exception.InternalError("%v", err)
@@ -48,6 +48,9 @@ func (l *Linter) ProcessPath(root string) ([]rules.Issue, error) {
 			pkgPaths: []string{root},
 			fset:     fset,
 			rules:    activeRules,
+			suppressions: map[string][]rules.Suppression{
+				root: rules.ProcessSuppressions(f.Comments, fset, f.Decls, f.Package),
+			},
 			shouldStop: func(current int) bool {
 				return l.MaxIssues > 0 && current >= l.MaxIssues
 			},
@@ -86,6 +89,8 @@ func (l *Linter) ProcessPath(root string) ([]rules.Issue, error) {
 					var pkgPaths []string
 					var pkgFiles []*ast.File
 
+					allSuppressions := make(map[string][]rules.Suppression)
+
 					// TODO: Review this later
 					for _, path := range job.files {
 						src, err := os.ReadFile(path)
@@ -94,13 +99,15 @@ func (l *Linter) ProcessPath(root string) ([]rules.Issue, error) {
 							continue
 						}
 
-						f, err := parser.ParseFile(fset, path, src, 0)
+						f, err := parser.ParseFile(fset, path, src, parser.ParseComments)
 
 						if err != nil {
 							fmt.Fprintf(os.Stderr, "Parse error in %s: %v\n", path, err)
 
 							continue
 						}
+
+						allSuppressions[path] = rules.ProcessSuppressions(f.Comments, fset, f.Decls, f.Package)
 
 						pkgFiles = append(pkgFiles, f)
 						pkgPaths = append(pkgPaths, path)
@@ -111,10 +118,11 @@ func (l *Linter) ProcessPath(root string) ([]rules.Issue, error) {
 					}
 
 					localIssues, err := l.Analyze(AnalysisParams{
-						pkgFiles: pkgFiles,
-						pkgPaths: pkgPaths,
-						fset:     fset,
-						rules:    activeRules,
+						pkgFiles:     pkgFiles,
+						pkgPaths:     pkgPaths,
+						fset:         fset,
+						rules:        activeRules,
+						suppressions: allSuppressions,
 						shouldStop: func(current int) bool {
 							return l.MaxIssues > 0 && int(atomic.LoadInt64(&totalIssues)) >= l.MaxIssues
 						},

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -20,9 +20,10 @@ type PackageJob struct {
 }
 
 type AnalysisParams struct {
-	pkgFiles   []*ast.File
-	pkgPaths   []string
-	fset       *token.FileSet
-	shouldStop func(int) bool
-	rules      map[reflect.Type][]rules.Rule
+	pkgFiles     []*ast.File
+	pkgPaths     []string
+	fset         *token.FileSet
+	shouldStop   func(int) bool
+	rules        map[reflect.Type][]rules.Rule
+	suppressions map[string][]rules.Suppression
 }

--- a/internal/rules/messages.go
+++ b/internal/rules/messages.go
@@ -50,6 +50,10 @@ var registry = map[uint16]RuleMetadata{
 
 	// ---- STYLE ---
 	PreferIncDecID: {ID: PreferIncDecID, Name: "prefer-inc-dec", Template: "Prefer ++ or -- instead of += 1 / -= 1 operations"},
+
+	// ---- SUPPRESSION ----
+	UnusedSuppressionID:       {ID: UnusedSuppressionID, Name: "unused-suppression", Template: "suppression for rule %q is unused"},
+	MisplacedFileWideIgnoreID: {ID: MisplacedFileWideIgnoreID, Name: "misplaced-file-wide-ignore", Template: "file-wide ignore for rule %q should be placed before package declaration"},
 }
 
 func GetMetadata(id uint16) (RuleMetadata, bool) {
@@ -81,7 +85,9 @@ func FormatMessage(issue Issue) string {
 		ImportedIdentifiersID,
 		RedundantImportAliasID,
 		NoMagicNumbersID,
-		DisallowedPackagesID:
+		DisallowedPackagesID,
+		UnusedSuppressionID,
+		MisplacedFileWideIgnoreID:
 		return fmt.Sprintf(meta.Template, issue.ArgStr1)
 
 	default:

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -18,6 +18,7 @@ type Runner struct {
 	MutatedObjects map[types.Object]bool
 	TypesInfo      *types.Info
 	IssuesCount    *uint16
+	Suppressions   []Suppression
 }
 
 type LinterOptions struct {
@@ -273,4 +274,9 @@ const (
 	// STYLE
 
 	PreferIncDecID
+
+	// SUPPRESSION
+
+	UnusedSuppressionID
+	MisplacedFileWideIgnoreID
 )

--- a/internal/rules/suppression.go
+++ b/internal/rules/suppression.go
@@ -1,19 +1,189 @@
 package rules
 
 import (
-	"fmt"
 	"go/ast"
+	"go/token"
+	"regexp"
+	"strings"
 )
 
 type Suppression struct {
-	RuleName string
-	Reason   string
-	Line     int
+	RuleName    string
+	Reason      string
+	Line        int
+	IsFileWide  bool // If true, applies to all occurrences in the file
+	IsMisplaced bool // If true, file-wide ignore is placed after package declaration
 }
 
-func ProcessSuppressions(comments []*ast.CommentGroup) []Suppression {
-	for _, comment := range comments {
-		fmt.Println(comment.Text())
+var (
+	inlineRegex   = regexp.MustCompile(`@serenity-ignore\s+([\w-]+)(?::\s*(.+))?`)
+	fileWideRegex = regexp.MustCompile(`@serenity-ignore-all\s+([\w-]+)(?::\s*(.+))?`)
+)
+
+func ProcessSuppressions(comments []*ast.CommentGroup, fset *token.FileSet, decls []ast.Decl, pkgPos token.Pos) []Suppression {
+	var suppressions []Suppression
+
+	pkgLine := fset.Position(pkgPos).Line
+
+	firstDeclLine := 0
+	if len(decls) > 0 {
+		firstDeclLine = fset.Position(decls[0].Pos()).Line
 	}
-	return []Suppression{}
+
+	for _, cg := range comments {
+		if cg == nil {
+			continue
+		}
+
+		for _, comment := range cg.List {
+			if comment == nil {
+				continue
+			}
+
+			line := fset.Position(comment.Pos()).Line
+
+			sup := parseSuppression(comment.Text, line, firstDeclLine, pkgLine)
+			if sup != nil {
+				suppressions = append(suppressions, *sup)
+			}
+		}
+	}
+
+	return suppressions
+}
+
+func parseSuppression(text string, line int, firstDeclLine int, pkgLine int) *Suppression {
+	text = strings.TrimSpace(text)
+
+	if match := fileWideRegex.FindStringSubmatch(text); match != nil {
+		misplaced := line >= pkgLine
+
+		ruleName := match[1]
+		reason := ""
+		if len(match) > 2 {
+			reason = match[2]
+		}
+
+		return &Suppression{
+			RuleName:    ruleName,
+			Reason:      reason,
+			Line:        line,
+			IsFileWide:  true,
+			IsMisplaced: misplaced,
+		}
+	}
+
+	if match := inlineRegex.FindStringSubmatch(text); match != nil {
+		ruleName := match[1]
+		reason := ""
+		if len(match) > 2 {
+			reason = match[2]
+		}
+
+		return &Suppression{
+			RuleName:   ruleName,
+			Reason:     reason,
+			Line:       line,
+			IsFileWide: false,
+		}
+	}
+
+	return nil
+}
+
+func GetRuleName(id uint16) string {
+	meta, ok := GetMetadata(id)
+	if !ok {
+		return ""
+	}
+	return meta.Name
+}
+
+func FilterSuppressedIssues(issues []Issue, suppressions []Suppression) []Issue {
+	var filtered []Issue
+
+	for _, issue := range issues {
+		ruleName := GetRuleName(issue.ID)
+		if ruleName == "" {
+			filtered = append(filtered, issue)
+			continue
+		}
+
+		suppressed := false
+
+		for _, sup := range suppressions {
+			if sup.RuleName != ruleName {
+				continue
+			}
+
+			if sup.IsFileWide {
+				suppressed = true
+				break
+			}
+
+			// Inline suppression applies to the same line or the next line
+			if sup.Line == issue.Pos.Line || sup.Line+1 == issue.Pos.Line {
+				suppressed = true
+				break
+			}
+		}
+
+		if !suppressed {
+			filtered = append(filtered, issue)
+		}
+	}
+
+	return filtered
+}
+
+func CheckUnusedSuppressions(issues []Issue, suppressions []Suppression) []Issue {
+	var warnings []Issue
+
+	for _, sup := range suppressions {
+		if sup.IsMisplaced {
+			warnings = append(warnings, Issue{
+				ID:       MisplacedFileWideIgnoreID,
+				Pos:      token.Position{Line: sup.Line},
+				Severity: SeverityWarn,
+				ArgStr1:  sup.RuleName,
+			})
+			continue
+		}
+
+		used := false
+
+		for _, issue := range issues {
+			ruleName := GetRuleName(issue.ID)
+			if ruleName != sup.RuleName {
+				continue
+			}
+
+			if sup.IsFileWide {
+				used = true
+				break
+			}
+
+			// Inline suppression applies to the same line or the next line
+			if sup.Line == issue.Pos.Line || sup.Line+1 == issue.Pos.Line {
+				used = true
+				break
+			}
+		}
+
+		if !used {
+			pos := token.Position{Line: sup.Line}
+			if sup.IsFileWide {
+				pos.Line = 1
+			}
+
+			warnings = append(warnings, Issue{
+				ID:       UnusedSuppressionID,
+				Pos:      pos,
+				Severity: SeverityWarn,
+				ArgStr1:  sup.RuleName,
+			})
+		}
+	}
+
+	return warnings
 }

--- a/internal/rules/suppression.go
+++ b/internal/rules/suppression.go
@@ -1,0 +1,19 @@
+package rules
+
+import (
+	"fmt"
+	"go/ast"
+)
+
+type Suppression struct {
+	RuleName string
+	Reason   string
+	Line     int
+}
+
+func ProcessSuppressions(comments []*ast.CommentGroup) []Suppression {
+	for _, comment := range comments {
+		fmt.Println(comment.Text())
+	}
+	return []Suppression{}
+}

--- a/internal/rules/suppression.go
+++ b/internal/rules/suppression.go
@@ -25,11 +25,6 @@ func ProcessSuppressions(comments []*ast.CommentGroup, fset *token.FileSet, decl
 
 	pkgLine := fset.Position(pkgPos).Line
 
-	firstDeclLine := 0
-	if len(decls) > 0 {
-		firstDeclLine = fset.Position(decls[0].Pos()).Line
-	}
-
 	for _, cg := range comments {
 		if cg == nil {
 			continue
@@ -42,7 +37,7 @@ func ProcessSuppressions(comments []*ast.CommentGroup, fset *token.FileSet, decl
 
 			line := fset.Position(comment.Pos()).Line
 
-			sup := parseSuppression(comment.Text, line, firstDeclLine, pkgLine)
+			sup := parseSuppression(comment.Text, line, pkgLine)
 			if sup != nil {
 				suppressions = append(suppressions, *sup)
 			}
@@ -52,7 +47,7 @@ func ProcessSuppressions(comments []*ast.CommentGroup, fset *token.FileSet, decl
 	return suppressions
 }
 
-func parseSuppression(text string, line int, firstDeclLine int, pkgLine int) *Suppression {
+func parseSuppression(text string, line int, pkgLine int) *Suppression {
 	text = strings.TrimSpace(text)
 
 	if match := fileWideRegex.FindStringSubmatch(text); match != nil {


### PR DESCRIPTION
<!-- We appreciate this so much. Thanks! -->

## Summary

Suppressing rules via comments:
- File-wide ignore comment : `// serenity-ignore-all <rule>: <reason>`
- Inline ignore comment : `// serenity-ignore <rule>: <reason>`

Important notes:

- Go parser give us the position of `package` keyword in the `File` struct which makes it so easy and efficient to make sure that all file-wide ignores can only live in the top of file. This way we don't need to deal with range with line ranges (let's say verifying the first N lines) or keep track of the first declaration position.

- It was not a discussed feature, but I have added a way to warn the user about misplacing the file-wide comment (declaring it after `package`).

## Related Issue

No issue.

## Why

Serenity's users are able to ignore some specific warnings directly in the code without messing up with the Serenity config file.

## What changed

- Pipeline has new changes to make sure that we are parsing the suppression comments in parallel as well
- Go file parses got a new mode to make sure that we are actually retrieving the comment groups (by default, go parser does not retrieve comment groups, you have to specify a different mode for it)
- We also need to ensure we are keeping track of unused ignore comments (let's say you have a comment for ignoring some specific warning that does not even exists there, we need to avoid 'dead comments'

## Breaking changes

- [ ] Yes
- [x] No

## Checklist

- [ ] CI passing
- [ ] Docs updated
- [ ] I followed the CONTRIBUTING guidelines
- [ ] I added or updated tests (if applicable)

## Additional context

1. Correct file-wide ignore comment

```go
// @serenity-ignore-all max-params
package main
func TestFunc(a, b, c, d, e, f int) int {
	return a + b + c + d + e + f
}
```

2. Misplaced file-wide ignore comment

```go
package main
// @serenity-ignore-all max-params
func TestFunc(a, b, c, d, e, f int) int {
	return a + b + c + d + e + f
}
```

```
:3:0: [file-wide ignore for rule "max-params" should be placed before package declaration] WARN
Error: internal error: issues found
```

3. Proper inline ignore comment (same line)

```go
package main
func TestFunc(a, b, c, d, e, f int) int { // @serenity-ignore max-params
	return a + b + c + d + e + f
}
```

4. Proper inline ignore comment (one line above)

```go
package main
// @serenity-ignore max-params
func TestFunc(a, b, c, d, e, f int) int {
	return a + b + c + d + e + f
}
```

5. Inline ignore comment for rule that does not exists

```go
package main
// @serenity-ignore non-existent-rule
func TestFunc(a, b int) int {
	return a + b
}
```

```
:3:0: [suppression for rule "non-existent-rule" is unused] WARN
Error: internal error: issues found
```

6. Mixed ignore comments

```go
// @serenity-ignore-all max-params
package main
// max-params suppressed by file-wide
func HasManyParams(a, b, c, d, e, f int) int {
	return a + b + c + d + e + f
}
// This has no issues
func NoIssues(a, b int) int {
	return a + b
}
```